### PR TITLE
nit: detailed `error`

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,7 +38,7 @@ function App() {
     return <div>Fetching data...</div>
   }
   if (error) {
-    return <div className='p-2 font-mono'>Invalid `APP_ID`. Go to <a href="https://instantdb.com/dash" className='underline text-blue-500'>https://instantdb.com/dash</a> to get a new `APP_ID`</div>
+    return <div className='p-2 font-mono'>{JSON.stringify(error, null, 2)}</div>
   }
   const { messages } = data
 


### PR DESCRIPTION
I was debugging the `data.ref` issue we were having, and noticed that whenever we had an error, we defaulted to the "invalid app id" message. 

Updated the template to straight print `error`, which would have a more detailed message.

@nezaj 

--- 

Note: I made this as a PR through the UI -- mainly opened it as a place to have the discussion. If you think of a better thing to print out, feel free 🫡